### PR TITLE
Update branch naming conventions

### DIFF
--- a/DEVNOTES
+++ b/DEVNOTES
@@ -3,12 +3,27 @@ Progena Dev Notes
 Protected Branches:
 
 main (primary branch)
-dev (staging before merge into master)
+dev (staging before merge into main)
 
 Branches:
 
-wip/... (experimental functionality or preparation that is not ready for release to main branch)
-feature/... (specific features and tasks that are purposed for release into main branch)
+wip/... (experimental functionality or preparation that is not ready for
+release to main branch)
+
+feature/... (specific features and tasks that are purposed for release into
+main branch)
+
 bug/... (quick/temporary fixes for minor issues into main branch)
-crit/... (vulnerability or broken functionality fixes that need immediate resolution into main branch)
+
+crit/... (vulnerability or broken functionality fixes that need immediate
+resolution into main branch)
+
 docs/... (docs changes)
+
+Merges & Pull Requests:
+
+wip/... and feature/... and docs/... branches should be merged into dev branch
+and then merged into main by pull requests
+
+bug/... & crit/... branches can be merged directly into main if appropriate
+or if time-critical

--- a/DEVNOTES
+++ b/DEVNOTES
@@ -5,23 +5,10 @@ Protected Branches:
 main (primary branch)
 dev (staging before merge into master)
 
-Temporary Branches:
+Branches:
 
-feature/... (specific features and tasks)
-bugfix/... (quick fixes that don't need immediate resolution, --> dev --> main)
+wip/... (experimental functionality or preparation that is not ready for release to main branch)
+feature/... (specific features and tasks that are purposed for release into main branch)
+bug/... (quick/temporary fixes for minor issues into main branch)
+crit/... (vulnerability or broken functionality fixes that need immediate resolution into main branch)
 docs/... (docs changes)
-
-Commits:
-
-Start with...
-
-feat: ... (new feature)
-fix: ... (bug fix)
-perf: ... (performance improvement)
-refactor: ... (code changes that don't fix bugs or adds features)
-style: ... (whitespace, formatting)
-test: ... (testing code)
-docs: ... (for use with docs/... branches)
-other: ... (for things that deviate from the above)
-
-...then give a detailed explanation of what was done


### PR DESCRIPTION
Branch and commit conventions were too complicated for a solo project, so it has been simplified.